### PR TITLE
reviewer-lottery 워크플로우 추가

### DIFF
--- a/.github/workflows/reviewer-lottery.yml
+++ b/.github/workflows/reviewer-lottery.yml
@@ -1,0 +1,13 @@
+name: "Reviewer lottery"
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: uesteibar/reviewer-lottery@v1
+        with:
+          repo-token: ${{ secrets.JYP_TOKEN }}


### PR DESCRIPTION
### 실제 소요시간
0.5h

### 설명

- .github/workflows에 있는 reviewer-lottery는 실제로 request가 일어나는 경우 랜덤으로 리뷰어 배정
- .github/reviewer-lottery에는 workflows에서 실행될 때 config가 들어있음
