### PR TITLE
[#69] 전역 상태: optionStore 작성

### DIFF
--- a/client/src/components/ProductList/mock/api.ts
+++ b/client/src/components/ProductList/mock/api.ts
@@ -32,5 +32,7 @@ const sortProductList = (productList: Array<ProductItemType>, order: ProductList
         (a: ProductItemType, b: ProductItemType) =>
           new Date(b.uploadDate).getTime() - new Date(a.uploadDate).getTime()
       );
+    default:
+      return [...productList];
   }
 };

--- a/client/src/stores/optionStore.ts
+++ b/client/src/stores/optionStore.ts
@@ -3,8 +3,10 @@ import { Option } from '../types/option';
 import { ProductListOrder } from '../types/product';
 
 const DEFAULT_OPTION: Option = {
+  categoryId: null,
   sortOption: ProductListOrder.Recommend,
   pageNum: 1,
+  searchTerm: null,
 };
 
 class OptionStore {

--- a/client/src/stores/optionStore.ts
+++ b/client/src/stores/optionStore.ts
@@ -9,16 +9,39 @@ const DEFAULT_OPTION: Option = {
   searchTerm: null,
 };
 
+const SORT_OPTION: { [key: string]: ProductListOrder } = {
+  recommend: ProductListOrder.Recommend,
+  popularity: ProductListOrder.Popularity,
+  recent: ProductListOrder.Recent,
+  priceHigh: ProductListOrder.PriceHigh,
+  priceLow: ProductListOrder.PriceLow,
+};
+
 class OptionStore {
   @observable
-  option: Option = DEFAULT_OPTION;
+  option: Option;
 
   constructor() {
     makeAutoObservable(this);
+    this.option = this.parseQueryToOption();
+  }
+
+  private resetOption = () => (this.option = DEFAULT_OPTION);
+
+  private parseQueryToOption() {
+    const queryParams = new URLSearchParams(window.location.search);
+
+    const categoryId = +(queryParams.get('category') || '') || DEFAULT_OPTION.categoryId;
+    const sortOption = SORT_OPTION[queryParams.get('sort') || ''] || DEFAULT_OPTION.sortOption;
+    const pageNum = +(queryParams.get('pageNum') || '') || DEFAULT_OPTION.pageNum;
+    const searchTerm = queryParams.get('search') || DEFAULT_OPTION.searchTerm;
+
+    return { categoryId, sortOption, pageNum, searchTerm };
   }
 
   @action
   setCategory(categoryId: number) {
+    this.resetOption();
     this.option.categoryId = categoryId;
   }
 
@@ -34,6 +57,7 @@ class OptionStore {
 
   @action
   setSearchTerm(searchTerm: string) {
+    this.resetOption();
     this.option.searchTerm = searchTerm;
   }
 }

--- a/client/src/stores/optionStore.ts
+++ b/client/src/stores/optionStore.ts
@@ -1,0 +1,39 @@
+import { action, makeAutoObservable, observable } from 'mobx';
+import { Option } from '../types/option';
+import { ProductListOrder } from '../types/product';
+
+const DEFAULT_OPTION: Option = {
+  sortOption: ProductListOrder.Recommend,
+  pageNum: 1,
+};
+
+class OptionStore {
+  @observable
+  option: Option = DEFAULT_OPTION;
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  @action
+  setCategory(categoryId: number) {
+    this.option.categoryId = categoryId;
+  }
+
+  @action
+  setSortOption(sortOption: ProductListOrder) {
+    this.option.sortOption = sortOption;
+  }
+
+  @action
+  setPageNum(pageNum: number) {
+    this.option.pageNum = pageNum;
+  }
+
+  @action
+  setSearchTerm(searchTerm: string) {
+    this.option.searchTerm = searchTerm;
+  }
+}
+
+export default new OptionStore();

--- a/client/src/types/option.ts
+++ b/client/src/types/option.ts
@@ -1,0 +1,8 @@
+import { ProductListOrder } from '../types/product';
+
+export type Option = {
+  categoryId?: number;
+  sortOption: ProductListOrder;
+  pageNum: number;
+  searchTerm?: string;
+};

--- a/client/src/types/option.ts
+++ b/client/src/types/option.ts
@@ -1,8 +1,8 @@
 import { ProductListOrder } from '../types/product';
 
 export type Option = {
-  categoryId?: number;
+  categoryId: number | null;
   sortOption: ProductListOrder;
   pageNum: number;
-  searchTerm?: string;
+  searchTerm: string | null;
 };

--- a/client/src/types/product.ts
+++ b/client/src/types/product.ts
@@ -14,6 +14,7 @@ export type ProductItemType = {
 };
 
 export enum ProductListOrder {
+  Recommend,
   Popularity,
   Recent,
   PriceLow,


### PR DESCRIPTION
### 관련이슈
- #69 

### 실제 소요시간
1.0h

### 체크리스트
- [x] `base branch`를 확인했나요?

### 설명
- 다른 컴포넌트에서 구독하고 값이 잘 바뀌는 것까지 확인했습니다. (코드에 반영하지는 않음)

### 논의되어야 할 부분
- Option 타입 정의
- optionStore.option의 디폴트 값
- 쿼리가 포함된 URL이 직접 입력(또는 redirect, 새로 고침 등)될 경우 option을 생성할 때 값을 넣어줘야 할 듯?..
- /api/product 요청시 option값(categoryId나 searchTerm 등)이 없는 경우(또는 디폴트값을 준다면 디폴트값)에 대한 처리를 어디에서 해주고 url query를 빌드할 것인지
- 카테고리 전환 또는 검색어 입력시에 다른 옵션들이 남아있게 되는 문제 처리 방법(?) (예: A 카테고리에서 인기순으로 보고 있다가 B 카테고리로 간다면 option.categoryId 값은 변경되지만, option.sortOption은 그대로이기 때문에 기본 옵션인 추천순이 아닌 인기순으로 목록이 정렬됨)