### PR TITLE
[#139] 마이페이지 기본 레이아웃

### DIFF
--- a/client/src/components/Account/AccountLanding/AccountLanding.tsx
+++ b/client/src/components/Account/AccountLanding/AccountLanding.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+import User from '../../../models/user';
+
+const Container = styled.div`
+  font-size: ${(props) => props.theme.fontSize.medium};
+`;
+
+type Props = {
+  user: User;
+};
+const AccountLanding = (props: Props): JSX.Element => {
+  const { user } = props;
+
+  return <Container>환영합니다, {user.name} 님</Container>;
+};
+
+export default AccountLanding;

--- a/client/src/components/Account/AccountNavList/AccountNavList.tsx
+++ b/client/src/components/Account/AccountNavList/AccountNavList.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from '../../../lib/router';
+
+const PAGE_TITLE_TEXT = '마이페이지';
+
+const Container = styled.nav`
+  width: 200px;
+  margin-right: 120px;
+`;
+
+const PageTitle = styled.h2`
+  font-size: 20px;
+  padding: 0 0 16px 8px;
+  border-bottom: 1px solid ${(props) => props.theme.color.grey1};
+`;
+
+const NavList = styled.ul`
+  padding-left: 10px;
+  margin-top: 16px;
+`;
+
+const NavListItem = styled.li`
+  font-size: ${(props) => props.theme.fontSize.small};
+  margin: 16px 0;
+`;
+
+type Props = {
+  pathTextList: { path: string; text: string }[];
+};
+const AccountNavList = (props: Props): JSX.Element => {
+  const { pathTextList } = props;
+
+  const NavListItems = pathTextList.map(({ path, text }, i) => (
+    <NavListItem key={i}>
+      <Link to={path}>{text}</Link>
+    </NavListItem>
+  ));
+
+  return (
+    <Container>
+      <PageTitle>
+        <Link to="/account">{PAGE_TITLE_TEXT}</Link>
+      </PageTitle>
+      <NavList>{NavListItems}</NavList>
+    </Container>
+  );
+};
+
+export default AccountNavList;

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -27,7 +27,7 @@ const App = (): JSX.Element => {
           <Route exact path="/logout" component={LogoutPage} />
           <Route exact path="/product/:id" component={ProductPage} />
           <Route exact path="/products" component={ProductsPage} />
-          <Route exact path="/account" component={AccountPage} />
+          <Route path="/account" component={AccountPage} />
           <Route exact path="/error" component={ErrorPage} />
           <Route path="/" component={NotfoundPage} />
         </Switch>

--- a/client/src/pages/Account.tsx
+++ b/client/src/pages/Account.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Route, Switch } from '../lib/router';
-import AccountNavList from '../components/AccountNavList/AccountNavList';
+import AccountNavList from '../components/Account/AccountNavList/AccountNavList';
+import AccountLanding from '../components/Account/AccountLanding/AccountLanding';
 import ManageDeliveryAddressContainer from '../containers/ManageDeliveryAddressContainer';
 import userStore from '../stores/userStore';
 import { observer } from 'mobx-react';
@@ -27,10 +28,6 @@ const RouteContainer = styled.div`
   display: flex;
 `;
 
-const AccountWelcome = styled.div`
-  font-size: ${(props) => props.theme.fontSize.medium};
-`;
-
 const NotUser = styled.div``;
 
 const AccountPage = (): JSX.Element => {
@@ -45,7 +42,7 @@ const AccountPage = (): JSX.Element => {
       <RouteContainer>
         <Switch>
           <Route exact path={'/account'}>
-            <AccountWelcome>환영합니다, {userStore.user.name} 님</AccountWelcome>
+            <AccountLanding user={userStore.user} />
           </Route>
           {Routes}
         </Switch>

--- a/client/src/pages/Account.tsx
+++ b/client/src/pages/Account.tsx
@@ -32,7 +32,7 @@ const NotUser = styled.div``;
 
 const AccountPage = (): JSX.Element => {
   const Routes = PATH_ITEM_LIST.map(({ path, Component }, i) => (
-    <Route key={i} path={`/account/${path}`} component={Component} />
+    <Route exact key={i} path={`/account/${path}`} component={Component} />
   ));
   const pathTextList = PATH_ITEM_LIST.map(({ path, text }) => ({ path: `/account/${path}`, text }));
 

--- a/client/src/pages/Account.tsx
+++ b/client/src/pages/Account.tsx
@@ -1,7 +1,59 @@
 import React from 'react';
+import styled from 'styled-components';
+import { Route, Switch } from '../lib/router';
+import AccountNavList from '../components/AccountNavList/AccountNavList';
+import ManageDeliveryAddressContainer from '../containers/ManageDeliveryAddressContainer';
+import userStore from '../stores/userStore';
+import { observer } from 'mobx-react';
+
+type PathItem = {
+  path: string;
+  text: string;
+  Component: () => JSX.Element;
+};
+const PATH_ITEM_LIST: PathItem[] = [
+  { path: 'delivery-address', text: '배송지 관리', Component: ManageDeliveryAddressContainer },
+];
+
+const Container = styled.section`
+  width: ${(props) => props.theme.device.desktop};
+  margin: 0 auto;
+  padding: 48px 0;
+  display: flex;
+`;
+
+const RouteContainer = styled.div`
+  flex: 1;
+  display: flex;
+`;
+
+const AccountWelcome = styled.div`
+  font-size: ${(props) => props.theme.fontSize.medium};
+`;
+
+const NotUser = styled.div``;
 
 const AccountPage = (): JSX.Element => {
-  return <div>마이 페이지</div>;
+  const Routes = PATH_ITEM_LIST.map(({ path, Component }, i) => (
+    <Route key={i} path={`/account/${path}`} component={Component} />
+  ));
+  const pathTextList = PATH_ITEM_LIST.map(({ path, text }) => ({ path: `/account/${path}`, text }));
+
+  return userStore.user ? (
+    <Container>
+      <AccountNavList pathTextList={pathTextList} />
+      <RouteContainer>
+        <Switch>
+          <Route exact path={'/account'}>
+            <AccountWelcome>환영합니다, {userStore.user.name} 님</AccountWelcome>
+          </Route>
+          {Routes}
+        </Switch>
+      </RouteContainer>
+    </Container>
+  ) : (
+    <NotUser>로그인이 필요한 페이지입니다</NotUser>
+  );
 };
 
-export default AccountPage;
+export default observer(AccountPage);


### PR DESCRIPTION
### 관련이슈
- #139 

### 실제 소요시간
2h

### 체크리스트
- [x] `base branch`를 확인했나요?

### 설명
- 기본적인 레이아웃 잡기
- 마이페이지 좌측 네비게이션 메뉴 (Link)
- 메인 콘텐츠 부분 (Switch, Route)
- 라우터를 이렇게 사용하는게 맞는지 확실하지가 않네요. 한 번 체크해주시면 감사하겠습니다!!

### 논의가 필요한 부분
- 마이페이지의 메인 페이지 (/account)를 어떻게 구성할지
- 유저가 아닌 경우에 마이페이지, 장바구니 등에 접근했을 때 어떻게 처리할지

![화면 기록 2021-08-25 오전 12 30 34](https://user-images.githubusercontent.com/31500012/130645753-ba50d431-0127-4cd2-9cfe-d8efd9ecb228.gif)
