### PR TITLE
[#153] OptionStore 동작 방식 개선

### DIFF
--- a/client/src/api/product.ts
+++ b/client/src/api/product.ts
@@ -12,6 +12,7 @@ class ProductAPI {
 
   fetchProducts(token: string | null, option: Option): Promise<ProductResponse> {
     const query = buildQueryString(option);
+
     return request<ProductResponse>({
       url: `${this.baseURL}/api/product${query}`,
       headers: {

--- a/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.test.tsx
+++ b/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.test.tsx
@@ -6,7 +6,6 @@ import provideRouter2Test from '../../../../lib/provideRouter2Test';
 import CategoryLayer, { Props } from './CategoryLayer';
 import Category from '../../../../models/category';
 import userEvent from '@testing-library/user-event';
-import { Option } from '../../../../types/option';
 
 describe('CategoryLayer 컴포넌트', () => {
   const PARENT_CATEGORY_NAME = '문구';
@@ -50,7 +49,6 @@ describe('CategoryLayer 컴포넌트', () => {
   const props: Props = {
     rootCategories,
     onCategoryClick,
-    option: {} as Option,
   };
 
   beforeEach(() => {

--- a/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
+++ b/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
@@ -5,6 +5,7 @@ import { CategoryClickHandler, CATEGORY_ALL } from '../../../../containers/Categ
 import Category from '../../../../models/category';
 import { Option } from '../../../../types/option';
 import { debounce, clearDebounce } from '../../../../lib/debounce';
+import { useEffect } from 'react';
 
 const Container = styled.div`
   position: absolute;
@@ -53,7 +54,7 @@ export type Props = {
 
 const CategoryLayer = (props: Props): JSX.Element => {
   const { rootCategories, onCategoryClick } = props;
-  const [currentCategory, setCurrentCategory] = useState(rootCategories[0]);
+  const [currentCategory, setCurrentCategory] = useState<null | Category>();
 
   const handleGetCategoryClickHandler = useCallback(
     (category: Category) => () => {
@@ -62,20 +63,26 @@ const CategoryLayer = (props: Props): JSX.Element => {
     [onCategoryClick]
   );
 
+  useEffect(() => {
+    if (rootCategories.length > 0) {
+      setCurrentCategory(rootCategories[0]);
+    }
+  }, [rootCategories]);
+
   const rootItems = rootCategories.map((category) => (
     <CategoryListItem
       key={category.id}
-      isCurrent={category.id === currentCategory.id}
+      isCurrent={category.id === currentCategory?.id}
       onMouseEnter={() => debounce(100, () => setCurrentCategory(category))}
       onClick={handleGetCategoryClickHandler(category)}
     >
-      <CategoryListItemText isCurrent={category.id === currentCategory.id}>
+      <CategoryListItemText isCurrent={category.id === currentCategory?.id}>
         {category.name}
       </CategoryListItemText>
     </CategoryListItem>
   ));
 
-  const childItems = currentCategory.childCategories.map((category) => (
+  const childItems = currentCategory?.childCategories.map((category) => (
     <CategoryListItem
       key={category.id}
       onMouseEnter={clearDebounce}
@@ -88,13 +95,15 @@ const CategoryLayer = (props: Props): JSX.Element => {
   return (
     <Container>
       <CategoryList isRoot={true}>{rootItems}</CategoryList>
-      {currentCategory !== CATEGORY_ALL && (
+      {currentCategory?.id !== CATEGORY_ALL?.id && (
         <CategoryList isRoot={false} data-testid="child-list">
           {childItems}
         </CategoryList>
       )}
     </Container>
   );
+
+  return <></>;
 };
 
 export default CategoryLayer;

--- a/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
+++ b/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
@@ -1,11 +1,9 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { rootListStyle, childListStyle, textUnderline } from './categoryLayerCss';
 import { CategoryClickHandler, CATEGORY_ALL } from '../../../../containers/CategoryLayerContainer';
 import Category from '../../../../models/category';
-import { Option } from '../../../../types/option';
 import { debounce, clearDebounce } from '../../../../lib/debounce';
-import { useEffect } from 'react';
 
 const Container = styled.div`
   position: absolute;
@@ -49,7 +47,6 @@ const CategoryListItemText = styled.span<CategoryListItemProps>`
 export type Props = {
   rootCategories: Category[];
   onCategoryClick: CategoryClickHandler;
-  option: Option;
 };
 
 const CategoryLayer = (props: Props): JSX.Element => {
@@ -102,8 +99,6 @@ const CategoryLayer = (props: Props): JSX.Element => {
       )}
     </Container>
   );
-
-  return <></>;
 };
 
 export default CategoryLayer;

--- a/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
+++ b/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
@@ -2,10 +2,8 @@ import React, { useState, useCallback } from 'react';
 import styled from 'styled-components';
 import { rootListStyle, childListStyle, textUnderline } from './categoryLayerCss';
 import { CategoryClickHandler, CATEGORY_ALL } from '../../../../containers/CategoryLayerContainer';
-import { useHistory } from '../../../../lib/router';
 import Category from '../../../../models/category';
 import { Option } from '../../../../types/option';
-import buildQueryString from '../../../../utils/build-query-string';
 import { debounce, clearDebounce } from '../../../../lib/debounce';
 
 const Container = styled.div`
@@ -54,21 +52,14 @@ export type Props = {
 };
 
 const CategoryLayer = (props: Props): JSX.Element => {
-  const { rootCategories, onCategoryClick, option } = props;
+  const { rootCategories, onCategoryClick } = props;
   const [currentCategory, setCurrentCategory] = useState(rootCategories[0]);
-  const history = useHistory();
 
   const handleGetCategoryClickHandler = useCallback(
     (category: Category) => () => {
-      const query = buildQueryString({
-        ...option,
-        category: category === CATEGORY_ALL ? null : category.id,
-        searchTerm: '',
-      });
-      history.push(`/products${query}`);
       onCategoryClick(category);
     },
-    [onCategoryClick, option, history]
+    [onCategoryClick]
   );
 
   const rootItems = rootCategories.map((category) => (

--- a/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
+++ b/client/src/components/Header/HeaderMain/CategoryMenu/CategoryLayer.tsx
@@ -95,7 +95,7 @@ const CategoryLayer = (props: Props): JSX.Element => {
   return (
     <Container>
       <CategoryList isRoot={true}>{rootItems}</CategoryList>
-      {currentCategory?.id !== CATEGORY_ALL?.id && (
+      {currentCategory?.id !== CATEGORY_ALL.id && (
         <CategoryList isRoot={false} data-testid="child-list">
           {childItems}
         </CategoryList>

--- a/client/src/components/PaymentFinish/ShippingInfo.tsx
+++ b/client/src/components/PaymentFinish/ShippingInfo.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import OrderFormRecipient from './OrderFormRecipient';
 import { useHistory } from '../../lib/router';
 import optionStore from '../../stores/optionStore';
-import buildQueryString from '../../utils/build-query-string';
 import User from '../../models/user';
 
 const Container = styled.div`
@@ -42,11 +41,8 @@ type Props = {
 const ShippingInfo = (props: Props): JSX.Element => {
   const { user, recipientName, address } = props;
   const history = useHistory();
-  const options = optionStore.option;
-
   const handleGoToProducts = () => {
-    const query = buildQueryString(options);
-    history.push(`/products${query}`);
+    history.push(`/products${optionStore.optionQuery}`);
   };
 
   return (

--- a/client/src/components/ProductList/ProductList.test.tsx
+++ b/client/src/components/ProductList/ProductList.test.tsx
@@ -26,7 +26,7 @@ describe('ProductList 테스트', () => {
       return;
     },
     onClickPageNum: (pageNum: number) => () => {
-      optionStore.setPageNum(pageNum);
+      optionStore.changePageNum(pageNum);
     },
   };
 

--- a/client/src/components/ProductList/SortButtonList.test.tsx
+++ b/client/src/components/ProductList/SortButtonList.test.tsx
@@ -17,7 +17,7 @@ describe('SortButtonList 테스트', () => {
   ];
 
   const handleSortButton = (sortOption: ProductListOrder) => () => {
-    optionStore.setSortOption(sortOption);
+    optionStore.changeSortOption(sortOption);
   };
 
   beforeEach(() => {

--- a/client/src/components/WishList/WishItem/WishItem.tsx
+++ b/client/src/components/WishList/WishItem/WishItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { Wish } from '../../../types/Wish';
 import { FaHeart } from 'react-icons/fa';
 import { useState } from 'react';
@@ -37,7 +37,7 @@ const WishButton = styled(CommonButton)<WishButtonProps>`
   background-color: ${(props) => props.theme.color.white1};
   width: 50px;
   font-size: ${(props) => props.theme.fontSize.large};
-color: ${(props) => (props.isWished ? props.theme.color.red : props.theme.color.grey3)};
+  color: ${(props) => (props.isWished ? props.theme.color.red : props.theme.color.grey3)};
 `;
 
 const ItemTitleWrapper = styled.div`

--- a/client/src/containers/CategoryLayerContainer.tsx
+++ b/client/src/containers/CategoryLayerContainer.tsx
@@ -5,6 +5,7 @@ import CategoryLayer, { Props } from '../components/Header/HeaderMain/CategoryMe
 import categoryStore from '../stores/categoryStore';
 import optionStore from '../stores/optionStore';
 import Category from '../models/category';
+import useOption from '../hooks/useOption';
 
 const Empty = styled.div``;
 
@@ -18,13 +19,14 @@ export const CATEGORY_ALL = new Category({
   isRoot: true,
 });
 
-const handleCategoryClick: CategoryClickHandler = (category: Category) => {
-  optionStore.setCategory(category.id);
-};
-
 const CategoryContainer = (): JSX.Element => {
+  const { changeCategory } = useOption();
   const categories = categoryStore.categories;
   const option = optionStore.option;
+
+  const handleCategoryClick: CategoryClickHandler = (category: Category) => {
+    changeCategory(category.id);
+  };
 
   if (categories.length === 0) {
     return <Empty />;

--- a/client/src/containers/CategoryLayerContainer.tsx
+++ b/client/src/containers/CategoryLayerContainer.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react';
 import styled from 'styled-components';
 import CategoryLayer, { Props } from '../components/Header/HeaderMain/CategoryMenu/CategoryLayer';
 import categoryStore from '../stores/categoryStore';
-import optionStore from '../stores/optionStore';
 import Category from '../models/category';
 import useOption from '../hooks/useOption';
 
@@ -22,7 +21,6 @@ export const CATEGORY_ALL = new Category({
 const CategoryContainer = (): JSX.Element => {
   const { changeCategory } = useOption();
   const categories = categoryStore.categories;
-  const option = optionStore.option;
 
   const handleCategoryClick: CategoryClickHandler = (category: Category) => {
     changeCategory(category.id);
@@ -38,7 +36,7 @@ const CategoryContainer = (): JSX.Element => {
     return <Empty />;
   }
 
-  const props: Props = { rootCategories, onCategoryClick: handleCategoryClick, option };
+  const props: Props = { rootCategories, onCategoryClick: handleCategoryClick };
   return <CategoryLayer {...props} />;
 };
 

--- a/client/src/containers/ProductListContainer.tsx
+++ b/client/src/containers/ProductListContainer.tsx
@@ -47,7 +47,7 @@ const ProductListContainer = (): JSX.Element => {
 
   useEffect(() => {
     const option = optionStore.parseQueryToOption(location.search);
-    console.log('pass');
+    optionStore.init(option);
     fetchProductList(option);
   }, [fetchProductList, history]);
 

--- a/client/src/containers/ProductListContainer.tsx
+++ b/client/src/containers/ProductListContainer.tsx
@@ -6,9 +6,9 @@ import Product from '../models/product';
 import { ProductListOrder } from '../types/product';
 import { observer } from 'mobx-react';
 import productStore from '../stores/productStore';
-import buildQueryString from '../utils/build-query-string';
 import { useHistory } from '../lib/router';
 import useWish from '../hooks/useWish';
+import useOption from '../hooks/useOption';
 
 export type SortButton = {
   key: ProductListOrder;
@@ -26,6 +26,7 @@ const SORT_BUTTONS = [
 const ProductListContainer = (): JSX.Element => {
   const [products, setProducts] = useState<Product[]>([]);
   const option = optionStore.option;
+  const { changeSortOption, changePageNum } = useOption();
   const totalPageCount = useRef(1);
   const totalProductCount = useRef(0);
   const history = useHistory();
@@ -45,32 +46,23 @@ const ProductListContainer = (): JSX.Element => {
   }, []);
 
   useEffect(() => {
+    const option = optionStore.parseQueryToOption(location.search);
+    console.log('pass');
     fetchProductList(option);
-  }, [option, option.category, option.pageNum, option.searchTerm, option.sort, fetchProductList]);
+  }, [fetchProductList, history]);
 
   const handleClickSortButton = useCallback(
     (order: ProductListOrder) => (): void => {
-      optionStore.setSortOption(order);
-      const query = buildQueryString({
-        ...option,
-        sort: order,
-      });
-      history.push(`/products${query}`);
+      changeSortOption(order);
     },
-    [option, history]
+    [changeSortOption]
   );
 
   const handleClickPageNum = useCallback(
     (pageNum: number) => () => {
-      optionStore.setPageNum(pageNum);
-      const query = buildQueryString({
-        ...option,
-        pageNum,
-      });
-      history.push(`/products${query}`);
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      changePageNum(pageNum);
     },
-    [option, history]
+    [changePageNum]
   );
 
   return (

--- a/client/src/containers/SearchBarContainer.tsx
+++ b/client/src/containers/SearchBarContainer.tsx
@@ -1,10 +1,10 @@
 import { observer } from 'mobx-react';
 import React, { MouseEventHandler, useCallback, useEffect, useState } from 'react';
 import SearchBar from '../components/Header/HeaderMain/SearchBar/SearchBar';
+import useOption from '../hooks/useOption';
 import { useHistory } from '../lib/router';
 import SearchTerm from '../models/searchTerm';
 import optionStore from '../stores/optionStore';
-import buildQueryString from '../utils/build-query-string';
 import { isNone, isNotNone } from '../utils/typeGuard';
 
 const SEARCH_TERM_LIST_KEY = 'search-term-list';
@@ -42,8 +42,7 @@ const getSearchTermList = (): SearchTerm[] => {
 const SearchBarContainer = (): JSX.Element => {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchTermList, setSearchTermList] = useState(getSearchTermList);
-  const option = optionStore.option;
-  const history = useHistory();
+  const { changeSearchTerm } = useOption();
 
   const handleChangeSearchTermInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value),
@@ -76,14 +75,7 @@ const SearchBarContainer = (): JSX.Element => {
 
     setSearchTerm('');
 
-    const query = buildQueryString({
-      ...option,
-      searchTerm: inputSearchTerm,
-      category: '',
-    });
-
-    history.push(`/products${query}`);
-    optionStore.setSearchTerm(inputSearchTerm);
+    changeSearchTerm(inputSearchTerm);
   };
 
   const handleChangeSearchTermList = () => {

--- a/client/src/containers/SearchBarContainer.tsx
+++ b/client/src/containers/SearchBarContainer.tsx
@@ -2,9 +2,7 @@ import { observer } from 'mobx-react';
 import React, { MouseEventHandler, useCallback, useEffect, useState } from 'react';
 import SearchBar from '../components/Header/HeaderMain/SearchBar/SearchBar';
 import useOption from '../hooks/useOption';
-import { useHistory } from '../lib/router';
 import SearchTerm from '../models/searchTerm';
-import optionStore from '../stores/optionStore';
 import { isNone, isNotNone } from '../utils/typeGuard';
 
 const SEARCH_TERM_LIST_KEY = 'search-term-list';

--- a/client/src/hooks/useOption.ts
+++ b/client/src/hooks/useOption.ts
@@ -1,0 +1,47 @@
+import { useHistory } from '../lib/router';
+import optionStore from '../stores/optionStore';
+import { ProductListOrder } from '../types/product';
+
+type UseOption = {
+  changeCategory: (categoryId: number) => void;
+  changeSortOption: (sortOption: ProductListOrder) => void;
+  changePageNum: (pageNum: number) => void;
+  changeSearchTerm: (searchTerm: string) => void;
+};
+
+const useOption = (): UseOption => {
+  const history = useHistory();
+
+  const handleChange = () => {
+    history.push(`/products${optionStore.optionQuery}`);
+  };
+
+  const handleChangeCategory = (categoryId: number) => {
+    optionStore.changeCategory(categoryId);
+    handleChange();
+  };
+
+  const handleChangeSortOption = (sortOption: ProductListOrder) => {
+    optionStore.changeSortOption(sortOption);
+    handleChange();
+  };
+
+  const handleChangePageNum = (pageNum: number) => {
+    optionStore.changePageNum(pageNum);
+    handleChange();
+  };
+
+  const handleChangeSearchTerm = (searchTerm: string) => {
+    optionStore.changeSearchTerm(searchTerm);
+    handleChange();
+  };
+
+  return {
+    changeCategory: handleChangeCategory,
+    changeSortOption: handleChangeSortOption,
+    changePageNum: handleChangePageNum,
+    changeSearchTerm: handleChangeSearchTerm,
+  };
+};
+
+export default useOption;

--- a/client/src/lib/router.tsx
+++ b/client/src/lib/router.tsx
@@ -52,6 +52,7 @@ type CompilePathParams = {
 
 type HistoryType = {
   push: (pathname: string) => void;
+  replace: (pathname: string) => void;
 };
 
 const RouterContext = createContext({} as RouterContextType);
@@ -90,11 +91,20 @@ export const Router = (props: RouterProps): React.ReactElement => {
     [history]
   );
 
+  const handleHistoryReplace = useCallback(
+    (pathname: string) => {
+      history.replaceState({}, pathname, window.location.origin + pathname);
+      setCurrentPath(pathname);
+    },
+    [history]
+  );
+
   return (
     <RouterContext.Provider
       value={{
         history: {
           push: handleHistoryPush,
+          replace: handleHistoryReplace,
         },
         currentPathname,
         setCurrentPath,

--- a/client/src/lib/router.tsx
+++ b/client/src/lib/router.tsx
@@ -70,7 +70,6 @@ export const Router = (props: RouterProps): React.ReactElement => {
   const { children } = props;
   const { history } = window;
   const routeInfo = { isMatch: true, keys: {} };
-  initialPath;
 
   const handlePopState = useCallback((event: PopStateEvent) => {
     event.preventDefault();

--- a/client/src/lib/router.tsx
+++ b/client/src/lib/router.tsx
@@ -64,15 +64,16 @@ const RouterContext = createContext({} as RouterContextType);
  */
 
 export const Router = (props: RouterProps): React.ReactElement => {
-  const initialPath = window.location.pathname;
+  const initialPath = `${window.location.pathname}${window.location.search}`;
   const [currentPathname, setCurrentPath] = useState(initialPath);
   const { children } = props;
   const { history } = window;
   const routeInfo = { isMatch: true, keys: {} };
+  initialPath;
 
   const handlePopState = useCallback((event: PopStateEvent) => {
     event.preventDefault();
-    const path = window.location.pathname;
+    const path = `${window.location.pathname}${window.location.search}`;
     setCurrentPath(path);
   }, []);
 
@@ -307,7 +308,10 @@ const compilePath = (params: CompilePathParams) => {
 export const matchPath = (params: MatchPathParams): MatchResult => {
   const { currentPathname, pathname, exact = false } = params;
 
-  const paths = pathname.split('/').filter((path) => path !== '');
+  const paths = pathname
+    .split('?')[0]
+    .split('/')
+    .filter((path) => path !== '');
   const currentPaths = removeUrlQuery(currentPathname)
     .split('/')
     .filter((path) => path !== '');

--- a/client/src/stores/optionStore.ts
+++ b/client/src/stores/optionStore.ts
@@ -46,10 +46,8 @@ class OptionStore {
   @action
   changeCategory(categoryId: number) {
     this.option = {
+      ...DEFAULT_OPTION,
       category: categoryId,
-      searchTerm: DEFAULT_OPTION.searchTerm,
-      pageNum: DEFAULT_OPTION.pageNum,
-      sort: DEFAULT_OPTION.sort,
     };
   }
 
@@ -73,10 +71,8 @@ class OptionStore {
   @action
   changeSearchTerm(searchTerm: string) {
     this.option = {
+      ...DEFAULT_OPTION,
       searchTerm,
-      category: DEFAULT_OPTION.category,
-      sort: DEFAULT_OPTION.sort,
-      pageNum: DEFAULT_OPTION.pageNum,
     };
   }
 

--- a/client/src/stores/optionStore.ts
+++ b/client/src/stores/optionStore.ts
@@ -27,6 +27,11 @@ class OptionStore {
     this.option = this.parseQueryToOption(window.location.search);
   }
 
+  @action
+  init(option: Option) {
+    this.option = option;
+  }
+
   parseQueryToOption(query: string) {
     const queryParams = new URLSearchParams(query);
 

--- a/client/src/stores/optionStore.ts
+++ b/client/src/stores/optionStore.ts
@@ -1,6 +1,7 @@
 import { action, makeAutoObservable, observable } from 'mobx';
 import { Option } from '../types/option';
 import { ProductListOrder } from '../types/product';
+import buildQueryString from '../utils/build-query-string';
 
 const DEFAULT_OPTION: Option = {
   category: null,
@@ -23,42 +24,59 @@ class OptionStore {
 
   constructor() {
     makeAutoObservable(this);
-    this.option = this.parseQueryToOption();
+    this.option = this.parseQueryToOption(window.location.search);
   }
 
-  private parseQueryToOption() {
-    const queryParams = new URLSearchParams(window.location.search);
+  parseQueryToOption(query: string) {
+    const queryParams = new URLSearchParams(query);
 
-    const category = +(queryParams.get('category') || '') || DEFAULT_OPTION.category;
-    const sort = SORT_OPTION[queryParams.get('sort') || ''] || DEFAULT_OPTION.sort;
-    const pageNum = +(queryParams.get('pageNum') || '') || DEFAULT_OPTION.pageNum;
-    const searchTerm = queryParams.get('search') || DEFAULT_OPTION.searchTerm;
+    const category = Number(queryParams.get('category')) || DEFAULT_OPTION.category;
+    const sort = SORT_OPTION[queryParams.get('sort') ?? DEFAULT_OPTION.sort];
+    const pageNum = Number(queryParams.get('pageNum')) ?? DEFAULT_OPTION.pageNum;
+    const searchTerm = queryParams.get('searchTerm') ?? DEFAULT_OPTION.searchTerm;
 
     return { category, sort, pageNum, searchTerm };
   }
 
   @action
-  setCategory(categoryId: number) {
-    this.option.searchTerm = null;
-    this.option.category = categoryId;
-    this.option.pageNum = 1;
+  changeCategory(categoryId: number) {
+    this.option = {
+      category: categoryId,
+      searchTerm: DEFAULT_OPTION.searchTerm,
+      pageNum: DEFAULT_OPTION.pageNum,
+      sort: DEFAULT_OPTION.sort,
+    };
   }
 
   @action
-  setSortOption(sortOption: ProductListOrder) {
-    this.option.sort = sortOption;
-    this.option.pageNum = 1;
+  changeSortOption(sortOption: ProductListOrder) {
+    this.option = {
+      ...this.option,
+      sort: sortOption,
+      pageNum: DEFAULT_OPTION.pageNum,
+    };
   }
 
   @action
-  setPageNum(pageNum: number) {
-    this.option.pageNum = pageNum;
+  changePageNum(pageNum: number) {
+    this.option = {
+      ...this.option,
+      pageNum,
+    };
   }
 
   @action
-  setSearchTerm(searchTerm: string) {
-    this.option.category = null;
-    this.option.searchTerm = searchTerm;
+  changeSearchTerm(searchTerm: string) {
+    this.option = {
+      searchTerm,
+      category: DEFAULT_OPTION.category,
+      sort: DEFAULT_OPTION.sort,
+      pageNum: DEFAULT_OPTION.pageNum,
+    };
+  }
+
+  get optionQuery(): string {
+    return buildQueryString(this.option);
   }
 }
 


### PR DESCRIPTION
### 관련이슈
- #153 

### 실제 소요시간
1.5h

### 체크리스트
- [ ] `base branch`를 확인했나요?

### 설명
변경점이 조금 많습니다.

__이슈__
- 기본의 라우터에선 path만 인식하고 query를 인식하지 않아 해당 부분에 대해서는 랜더링이 되지 않았습니다. 이로 인해 query도 인식하여 랜더링 할 수 있도록 변경했습니다. (앞으로, 뒤로가기 적용)

- optionStore의 데이터를 변경하고 history.push 하는 방식에서 `useOption` 훅을 통해서 한번에 처리할 수 있습니다. `ProductListContainer`는 오직 query를 반영하는 역할만 합니다.

- 카테고리쪽 테스트가 계속 터져서 삽질하던 중 props의 [0] 값을 바로 사용하는 경우를 확인했는데 이 부분에 대해 개선을 했습니다. (테스트는 로컬 문제로 생각됨)
