### PR TITLE
[#214] 마지막 검색어 입력 시 창이 닫히는 오류

### DIFF
--- a/client/src/containers/SearchBarContainer.tsx
+++ b/client/src/containers/SearchBarContainer.tsx
@@ -100,13 +100,15 @@ const SearchBarContainer = (): JSX.Element => {
     setSearchTermList([]);
   };
 
-  const getOnDeleteSearchTerm = (content: string) => () => {
-    const nextSearchTermList = searchTermList.filter((searchTerm) => {
-      return searchTerm.content !== content;
-    });
-
-    setSearchTermList(nextSearchTermList);
-  };
+  const getOnDeleteSearchTerm =
+    (content: string): MouseEventHandler =>
+    (e) => {
+      e.stopPropagation();
+      const nextSearchTermList = searchTermList.filter((searchTerm) => {
+        return searchTerm.content !== content;
+      });
+      setSearchTermList(nextSearchTermList);
+    };
 
   return (
     <SearchBar


### PR DESCRIPTION
### 관련이슈
- #214

### 실제 소요시간
0.5h

### 체크리스트
- [x] `base branch`를 확인했나요?

### 설명
어렵진 않지만 찾기 힘든 버그였네요 ㅎㅎ

__이슈__
이벤트는 아래와 같이 동작합니다.

1. 삭제 버튼 클릭
2. `setList`를 통해 `list`가 하나 줄어듬
3. document에 등록된 이벤트가 돌아서 search-bar 안에 없는 요소라면 모달창 닫힘

이때 문제는 2번 3번의 실행 순서인데 list가 이미 줄어들고 탐색을 하기에 당연히 `target.closest`가 `null`이 됨

> 그렇다면 마지막 요소가 아니라면?
> 디버깅 결과 해당 요소들은 `target`이 본인이 아닌 다음 요소로 잡혀있었고 마지막 요소는 다음 요소가 없어서 모달창이 닫힘
